### PR TITLE
Update BitMode representation

### DIFF
--- a/i2c_bitbang.py
+++ b/i2c_bitbang.py
@@ -18,6 +18,11 @@ class I2C:
     RESET = 1 << 5  # >=v2.0, <v2.0 has it on CDBUS4
     max_clock_stretch = 100
 
+    try:
+        BITMODE_BITBANG = Ftdi.BITMODE_BITBANG
+    except:
+        BITMODE_BITBANG = Ftdi.BitMode.BITBANG
+
     def __init__(self):
         self.dev = Ftdi()
         self._time = 0
@@ -39,7 +44,7 @@ class I2C:
 
     def set_direction(self, direction):
         self._direction = direction
-        self.dev.set_bitmode(direction, Ftdi.BitMode.BITBANG)
+        self.dev.set_bitmode(direction, self.BITMODE_BITBANG)
 
     def write(self, data):
         self.dev.write_data(bytes([data]))

--- a/i2c_bitbang.py
+++ b/i2c_bitbang.py
@@ -39,7 +39,7 @@ class I2C:
 
     def set_direction(self, direction):
         self._direction = direction
-        self.dev.set_bitmode(direction, Ftdi.BITMODE_BITBANG)
+        self.dev.set_bitmode(direction, Ftdi.BitMode.BITBANG)
 
     def write(self, data):
         self.dev.write_data(bytes([data]))


### PR DESCRIPTION
Fixes #3 : kasli-i2c no longer runs on the current version of pyftdi that ships from conda-forge (0.52.0). 

This change fixes incompatibility with:
https://github.com/eblot/pyftdi/commit/5d4be11ed8c22a5c0474ef797d08978a869ae86b#diff-59506818c26b3ffbf38ab767bc9a080c528daee33643289110907e757fa60df1
