### PR TITLE
support active LOW resets for Kasli <v2.0

### DIFF
--- a/kasli.py
+++ b/kasli.py
@@ -41,7 +41,13 @@ class Kasli(I2C, chips.ScanI2C):
 
     @contextmanager
     def enabled(self, *ports):
-        self.enable(*ports)
+        try:
+            self.enable(*ports)
+        except I2CNACK:  # Kasli < v2.0 has active LOW reset
+            self.set_reset_pol(False)
+            self.reset()
+            self.enable(*ports)
+
         try:
             yield self
         finally:


### PR DESCRIPTION
Closes #6

This autodetects the reset polarity as discussed, although I wonder if just making the hardware revision would be neater? That would also mean users don't have to think about the `port` parameter.